### PR TITLE
Update DESCRIPTION, missing comma causing install error.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Suggests:
     tibble,
     RSQLite
 Remotes: 
-    mikejohnson51/climateR
+    mikejohnson51/climateR,
     DOI-USGS/nhdplusTools,
     DOI-USGS/hyRefactor
 License: CC0


### PR DESCRIPTION
Very minor correction. 

Without it the following error was encountered on install:

Installing package into ‘/usr/local/lib/R/4.3/site-library’ (as ‘lib’ is unspecified)

Downloading GitHub repo NOAA-OWP/hydrofabric@HEAD

hydrofab     (NA -> 7d0c7e6e9...) [GitHub]
ngen.hydr... (NA -> f13b9557a...) [GitHub]
zonal        (NA -> 60032b949...) [GitHub]
climateR     (NA -> 81a644319...) [GitHub]
bit          (NA -> 4.0.5       ) [CRAN]
tidyselect   (NA -> 1.2.0       ) [CRAN]
bit64        (NA -> 4.0.5       ) [CRAN]
assertthat   (NA -> 0.2.1       ) [CRAN]
fstcore      (NA -> 0.9.18      ) [CRAN]
proxy        (NA -> 0.4-27      ) [CRAN]
units        (NA -> 0.8-5       ) [CRAN]
DBI          (NA -> 1.2.1       ) [CRAN]
wk           (NA -> 0.9.1       ) [CRAN]
e1071        (NA -> 1.7-14      ) [CRAN]
sf           (NA -> 1.0-15      ) [CRAN]
s2           (NA -> 1.1.6       ) [CRAN]
maplegend    (NA -> 0.1.0       ) [CRAN]
classInt     (NA -> 0.4-10      ) [CRAN]
sp           (NA -> 2.1-3       ) [CRAN]
raster       (NA -> 3.6-26      ) [CRAN]
slippymath   (NA -> 0.3.1       ) [CRAN]
terra        (NA -> 1.7-71      ) [CRAN]
png          (NA -> 0.1-8       ) [CRAN]
generics     (NA -> 0.1.3       ) [CRAN]
dplyr        (NA -> 1.1.4       ) [CRAN]
progress     (NA -> 1.2.3       ) [CRAN]
tzdb         (NA -> 0.4.0       ) [CRAN]
vroom        (NA -> 1.6.5       ) [CRAN]
hms          (NA -> 1.1.3       ) [CRAN]
timechange   (NA -> 0.3.0       ) [CRAN]
readr        (NA -> 2.1.5       ) [CRAN]
lubridate    (NA -> 1.9.3       ) [CRAN]
RANN         (NA -> 2.6.1       ) [CRAN]
tidyr        (NA -> 1.3.1       ) [CRAN]
pbapply      (NA -> 1.7-2       ) [CRAN]
data.table   (NA -> 1.15.0      ) [CRAN]
arrow        (NA -> 14.0.0.2    ) [CRAN]
fst          (NA -> 0.9.8       ) [CRAN]
mapsf        (NA -> 0.9.0       ) [CRAN]
maptiles     (NA -> 0.7.0       ) [CRAN]
dataRetri... (NA -> 2.7.14      ) [CRAN]
hydroloom    (NA -> 1.0.2       ) [CRAN]
plogr        (NA -> 0.2.0       ) [CRAN]
blob         (NA -> 1.2.4       ) [CRAN]
aws.signa... (NA -> 0.6.0       ) [CRAN]
nhdplusTools (NA -> 1.0.0       ) [CRAN]
RSQLite      (NA -> 2.3.5       ) [CRAN]
aws.s3       (NA -> 0.3.21      ) [CRAN]
Downloading GitHub repo mikejohnson51/hydrofab@HEAD

Error: Failed to install 'hydrofabric' from GitHub:
  Failed to install 'hydrofab' from GitHub:
  Missing commas separating Remotes: 'mikejohnson51/climateR
    DOI-USGS/nhdplusTools'
Traceback:

1. remotes::install_github("NOAA-OWP/hydrofabric")
2. install_remotes(remotes, auth_token = auth_token, host = host, 
 .     dependencies = dependencies, upgrade = upgrade, force = force, 
 .     quiet = quiet, build = build, build_opts = build_opts, build_manual = build_manual, 
 .     build_vignettes = build_vignettes, repos = repos, type = type, 
 .     ...)
3. tryCatch(res[[i]] <- install_remote(remotes[[i]], ...), error = function(e) {
 .     stop(remote_install_error(remotes[[i]], e))
 . })
4. tryCatchList(expr, classes, parentenv, handlers)
5. tryCatchOne(expr, names, parentenv, handlers[[1L]])
6. value[[3L]](cond)